### PR TITLE
fix: quote string unescape arg for fish 4.x compatibility

### DIFF
--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -31,14 +31,14 @@ if test "$KUBIE_PROMPT_DISABLE" = "0"
 
             # Fish's right prompt does not support newlines, so there's no point in
             # iterating through the (potentially) existing prompt's lines.
-            printf '%s %s' (string unescape {prompt}) $original
+            printf '%s %s' (string unescape '{prompt}') $original
         end
     else
         functions --copy fish_prompt fish_prompt_original
         function fish_prompt
             set -l original (fish_prompt_original)
 
-            printf '%s ' (string unescape {prompt})
+            printf '%s ' (string unescape '{prompt}')
 
             # Due to idiosyncrasies with the way fish is managing newlines in
             # process substitions, each line needs to be printed separately

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -31,14 +31,14 @@ if test "$KUBIE_PROMPT_DISABLE" = "0"
 
             # Fish's right prompt does not support newlines, so there's no point in
             # iterating through the (potentially) existing prompt's lines.
-            printf '%s %s' (string unescape '{prompt}') $original
+            printf '%s %s' (string unescape {prompt}) $original
         end
     else
         functions --copy fish_prompt fish_prompt_original
         function fish_prompt
             set -l original (fish_prompt_original)
 
-            printf '%s ' (string unescape '{prompt}')
+            printf '%s ' (string unescape {prompt})
 
             # Due to idiosyncrasies with the way fish is managing newlines in
             # process substitions, each line needs to be printed separately

--- a/src/shell/prompt.rs
+++ b/src/shell/prompt.rs
@@ -63,6 +63,11 @@ where
     fn start_color(&self, f: &mut fmt::Formatter, color: u32) -> fmt::Result {
         match self.shell_kind {
             ShellKind::Xonsh => self.isolate(f, format!("\\033[{color}m")),
+            // Fish needs the literal color sequences quoted: unquoted `\e[31m`
+            // parses as a glob bracket expression, which fish >= 4.9 rejects
+            // with "square brackets do not match". Command substitutions in the
+            // prompt stay unquoted so fish executes them.
+            ShellKind::Fish => self.isolate(f, format!("\"\\e[{color}m\"")),
             _ => self.isolate(f, format!("\\e[{color}m")),
         }
     }
@@ -70,6 +75,7 @@ where
     fn end_color(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.shell_kind {
             ShellKind::Xonsh => self.isolate(f, "\\033[0m"),
+            ShellKind::Fish => self.isolate(f, "\"\\e[0m\""),
             _ => self.isolate(f, "\\e[0m"),
         }
     }
@@ -120,5 +126,46 @@ pub fn generate_ps1(settings: &Settings, depth: u32, shell_kind: ShellKind) -> S
         parts.push(Color::new(BLUE, depth, shell_kind).to_string());
     }
 
-    format!("[{}]", parts.join("|"))
+    match shell_kind {
+        // Quote the surrounding brackets and separators for fish, for the same
+        // reason the color sequences are quoted above.
+        ShellKind::Fish => format!("\"[\"{}\"]\"", parts.join("\"|\"")),
+        _ => format!("[{}]", parts.join("|")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fish_prompt_quotes_literals_but_keeps_command_substitutions_unquoted() {
+        let prompt = generate_ps1(&Settings::default(), 2, ShellKind::Fish);
+
+        // Literal segments (colors, separators, brackets) must be quoted so fish
+        // >= 4.9 does not parse the unquoted prompt as a glob bracket expression.
+        assert!(prompt.starts_with("\"[\""), "expected quoted '[', got: {prompt}");
+        assert!(
+            prompt.contains("\"\\e[31m\""),
+            "expected quoted color escape, got: {prompt}"
+        );
+
+        // Command substitutions must stay unquoted so fish actually executes
+        // `kubie info ctx` / `kubie info ns` instead of printing them literally.
+        assert!(
+            prompt.contains("info ctx)\""),
+            "expected unquoted ctx command substitution, got: {prompt}"
+        );
+        assert!(
+            prompt.contains("info ns)\""),
+            "expected unquoted ns command substitution, got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn test_non_fish_prompt_is_unaffected() {
+        let prompt = generate_ps1(&Settings::default(), 2, ShellKind::Bash);
+        assert!(prompt.contains("\\e[31m"), "got: {prompt}");
+        assert!(!prompt.contains("\"\\e[31m\""), "got: {prompt}");
+    }
 }


### PR DESCRIPTION
## Problem

Fish 4.x parses unquoted backslash-escape sequences like `\e[` inside a
function body as a glob bracket expression, causing a
`Missing end to balance this function definition` syntax error when
kubie injects its prompt script (`kubie ctx`). Fixes #428.

An earlier iteration of this PR quoted the whole prompt
(`string unescape '{prompt}'`), which fixes the syntax error but also
disables the embedded command substitutions — `kubie info ctx` /
`kubie info ns` are no longer executed, so the prompt renders the
literal command text instead of the current context/namespace.

## Fix

Only the literal segments (color escapes, `|` separators, brackets) of
the generated fish prompt are quoted; the `(...)` command substitutions
stay unquoted so fish still executes them.

- `src/shell/fish.rs` is left as-is.
- `src/shell/prompt.rs` now emits, for `ShellKind::Fish`:
  `"[""\e[31m"(kubie info ctx)"\e[0m""|"..."\e[0m"]"`

This parses on fish >= 4.9 (no unquoted bracket glob) and on older fish
(unquoted `\e[` previously relied on glob pass-through), and the prompt
keeps executing `kubie info ctx` / `kubie info ns` on both.

## Verification

Tested with the real generated prompt + the fish.rs template on
fish 3.3.1, 3.6.1, 4.0.2 and 4.9.2: script parses and renders
`ctx|ns` (with colors) on all four. Added unit tests asserting the fish
prompt quotes literals but keeps command substitutions unquoted, and
that other shells are unaffected.